### PR TITLE
feat: axios 인스턴스 도메인별 2개로 분리, axiosCreate 함수 생성

### DIFF
--- a/src/apis/config.ts
+++ b/src/apis/config.ts
@@ -1,5 +1,22 @@
 import axios from 'axios';
 
-export const axiosInstance = axios.create({
-  baseURL: 'https://www.pre-onboarding-selection-task.shop/',
+const serverUrl = 'https://www.pre-onboarding-selection-task.shop';
+
+export const axiosCreate = () =>
+  axios.create({
+    baseURL: serverUrl,
+    headers: {
+      'content-type': 'application/json;charset=UTF-8',
+    },
+  });
+
+export const userInstance = axiosCreate();
+
+export const todoInstance = axiosCreate();
+
+todoInstance.interceptors.request.use(config => {
+  const token = localStorage.getItem('access_token');
+  config.headers.Authorization = `Bearer ${token}`;
+
+  return config;
 });

--- a/src/apis/todo.ts
+++ b/src/apis/todo.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios';
 
-import { axiosInstance } from './config';
+import { todoInstance } from './config';
 
 export const todoStatusObj = {
   get: 200,
@@ -17,23 +17,16 @@ export type TodoItem = {
 };
 
 const getTodos = (): Promise<AxiosResponse<TodoItem[]>> => {
-  return axiosInstance({
+  return todoInstance({
     url: 'todos',
     method: 'GET',
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('access_token')}`,
-    },
   });
 };
 
 const createTodo = (todo: string) => {
-  return axiosInstance({
+  return todoInstance({
     url: 'todos',
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('access_token')}`,
-      'Content-Type': 'application/json',
-    },
     data: {
       todo,
     },
@@ -41,24 +34,17 @@ const createTodo = (todo: string) => {
 };
 
 const updateTodo = (id: number, payload: { todo: string; isCompleted: boolean }) => {
-  return axiosInstance({
+  return todoInstance({
     url: `todos/${id}`,
     method: 'PUT',
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('access_token')}`,
-      'Content-Type': 'application/json',
-    },
     data: payload,
   });
 };
 
 const deleteTodo = (id: number) => {
-  return axiosInstance({
+  return todoInstance({
     url: `todos/${id}`,
     method: 'DELETE',
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('access_token')}`,
-    },
   });
 };
 

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,6 +1,6 @@
 import { TestId } from '../components/auth/AuthForm';
 
-import { axiosInstance } from './config';
+import { userInstance } from './config';
 
 export const authStatusCodeObj = {
   signup: 201,
@@ -8,23 +8,17 @@ export const authStatusCodeObj = {
 } as const;
 
 const signup = (data: Record<TestId['input'], string>) => {
-  return axiosInstance({
+  return userInstance({
     url: 'auth/signup',
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
     data,
   });
 };
 
 const signin = (data: Record<TestId['input'], string>) => {
-  return axiosInstance({
+  return userInstance({
     url: 'auth/signin',
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
     data,
   });
 };


### PR DESCRIPTION
## 요약
1차 회의에서 제시된 api의 Best Practice를 적용

## 구현 기능 명세
* 기존에 `user.ts`, `todo.ts`에서 공통 사용되던 axiosInstance를 userInstance, todoInstance로 분리
`config.ts` : axiosInstance -> userInstance, todoInstance
`user.ts` : axiosInstance -> userInstance
`todo.ts` : axiosInstance -> todoInstance
* Instance에서 중복된 코드(axios.Create)를 함수화(axiosCreate)
신승식님 createInstance 함수 예시 참조하여 함수명 수정해서 axiosCreate생성

## 어려웠던 점( 피드백 받고 싶은 부분 )
1. `Config.ts`에서 이미 존재하는 __'Content-Type' :  'application/json'을__ `user.ts`, `todo.ts`에서 __삭제__ 했는데 이부분이 적합한지 확인요청드립니다.
2. axios.Create의 반복을 없애기 위해 __axiosCreate__ 함수를 생성했는데 __함수명이 적합한지__ 확인요청드립니다.
3. (?) 파일 수정 전부터 __todo생성 후 todo입력칸이 초기화되지 않던데__ 해결하지 못하였습니다. 다른분들도 동일한 문제가 발생하는지 확인요청드립니다.
4. commit이 서툴러 `.eslintcache`까지 포함해버렸습니다. __해당 파일 제외__ 가능한지 확인요청드립니다.